### PR TITLE
Attempt to start datastore from IDE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <quarkus.http.test-host>localhost</quarkus.http.test-host>
+                        <quarkus.http.test-port>9080</quarkus.http.test-port>
+                        <quarkus.datasource.jdbc.url>jdbc:h2:/temp/DataStore_DataRoot/h2;MODE=PostgreSQL;INIT=CREATE SCHEMA IF NOT EXISTS datastore</quarkus.datasource.jdbc.url>
+                        <datastore.path>/temp/DataStore_DataRoot</datastore.path>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
 
             <!-- for COMMITrev_... reporting in .jars -->

--- a/src/test/java/cz/it4i/fiji/datastore/StartDataStoreServer.java
+++ b/src/test/java/cz/it4i/fiji/datastore/StartDataStoreServer.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 @QuarkusTest()
-public class startDataStoreServer {
+public class StartDataStoreServer {
 
 	@Test
 	public void testRunning() throws IOException {

--- a/src/test/java/cz/it4i/fiji/datastore/startDataStoreServer.java
+++ b/src/test/java/cz/it4i/fiji/datastore/startDataStoreServer.java
@@ -1,0 +1,19 @@
+package cz.it4i.fiji.datastore;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@QuarkusTest()
+public class startDataStoreServer {
+
+	@Test
+	public void testRunning() throws IOException {
+		System.out.println("just close me from IDE when done...");
+		new BufferedReader(new InputStreamReader(System.in)).readLine();
+		//NB: makes it wait forever...
+	}
+}


### PR DESCRIPTION
Hi guys,

I wanted to be able to start an instance of DataStore server from IDE so that I could be testing this DataStore and potentially see better where it is failing... I couldn't really figure out the proper way of starting the application (DataStore) so I faked it by looking around to the unit tests to see how they start the server.... and that's what's inside this PR...

Could you, please, help me figure out a nicer way? is there any? could we polish this PR that way?

Thanks and cheers,
Vlado 