### PR TITLE
Border tiles were missing in legacy bdv

### DIFF
--- a/src/main/java/cz/it4i/fiji/datastore/bdv_server/CellHandlerTS.java
+++ b/src/main/java/cz/it4i/fiji/datastore/bdv_server/CellHandlerTS.java
@@ -261,8 +261,9 @@ public class CellHandlerTS
 		}
 		else if (parts[0].equals("init"))
 		{
-			return respondWithString("application/json", buildMetadataJsonString(
-				spimdataSupplier.get(), datasetSupplier.get()));
+			Response retVal = respondWithString("application/json", buildMetadataJsonString(
+					spimdataSupplier.get(), datasetSupplier.get()));
+			return retVal;
 		}
 		return Response.status(Status.BAD_REQUEST).build();
 	}

--- a/src/main/java/cz/it4i/fiji/datastore/bdv_server/CellHandlerTS.java
+++ b/src/main/java/cz/it4i/fiji/datastore/bdv_server/CellHandlerTS.java
@@ -194,6 +194,7 @@ public class CellHandlerTS
 	{
 		String path = BdvN5Format.getPathName(key.setup, key.timepoint, key.level);
 		DatasetAttributes datasetAttributes = getDatasetAttributes(perPathDatasetAttribute, writer, path);
+		final int[][] blockSizes = metadata.getPerSetupMipmapInfo().get(key.setup).getSubdivisions();
 		long[] gridPosition = new long[cellMin.length];
 		for (int i = 0; i < gridPosition.length; i++) {
 			/*if (levelBlockSize[i] != cellDims[i] || cellMin[i] % cellDims[i] != 0) {
@@ -202,7 +203,7 @@ public class CellHandlerTS
 					Arrays.toString(levelBlockSize), Arrays.toString(cellMin), Arrays
 						.toString(cellDims)));
 			}*/
-			gridPosition[i] = cellMin[i] / cellDims[i];
+			gridPosition[i] = cellMin[i] / blockSizes[key.level][i];
 		}
 		DataBlock<?> result = writer.readBlock(path, datasetAttributes,
 			gridPosition);

--- a/src/main/java/cz/it4i/fiji/datastore/bdv_server/CellHandlerTS.java
+++ b/src/main/java/cz/it4i/fiji/datastore/bdv_server/CellHandlerTS.java
@@ -261,12 +261,16 @@ public class CellHandlerTS
 		}
 		else if (parts[0].equals("init"))
 		{
+			HPCDatastoreImageLoaderMetaData[] metadataArray = { null };
 			Response retVal = respondWithString("application/json", buildMetadataJsonString(
-					spimdataSupplier.get(), datasetSupplier.get()));
+					spimdataSupplier.get(), datasetSupplier.get(), metadataArray));
+			this.metadata = metadataArray[0];
 			return retVal;
 		}
 		return Response.status(Status.BAD_REQUEST).build();
 	}
+
+	HPCDatastoreImageLoaderMetaData metadata = null;
 
 	public Response runForDataset() {
 		final XmlIoSpimDataMinimal io = new XmlIoSpimDataMinimal();
@@ -300,17 +304,17 @@ public class CellHandlerTS
 	 * 
 	 */
 	private static String buildMetadataJsonString(SpimDataMinimal spimData,
-		Dataset dataset)
+		Dataset dataset, HPCDatastoreImageLoaderMetaData[] metaDataRetPtr)
 	{
 		final DatasetDTO datasetDTO = DatasetAssembler.createDatatransferObject(
 			dataset, spimData.getSequenceDescription().getTimePoints());
-		final HPCDatastoreImageLoaderMetaData metadata =
+		metaDataRetPtr[0] =
 			new HPCDatastoreImageLoaderMetaData(datasetDTO, spimData
 				.getSequenceDescription(), DataType.fromString(dataset.getVoxelType()));
 		final GsonBuilder gsonBuilder = new GsonBuilder();
 		gsonBuilder.registerTypeAdapter( AffineTransform3D.class, new AffineTransform3DJsonSerializer() );
 		gsonBuilder.enableComplexMapKeySerialization();
-		return gsonBuilder.create().toJson( metadata );
+		return gsonBuilder.create().toJson( metaDataRetPtr[0] );
 	}
 
 	private static String buildRemoteDatasetXML(XmlIoSpimDataMinimal io,


### PR DESCRIPTION
CellHandlerTS.readBlock() uses metadata to compute the gridPosition
properly, because the previous solution misunderstood the BDV's legacy
protocol in that the provided block size is not the usual block size
used for the given res. level, but the provided block size says what
size is required/what size shall be transferred... which is the same as
the "usual block size" for non-border tiles/cells, but exactly in the
border tiles/cells it may (not necessarily always will) be failing

![Screenshot_20230609_194400](https://github.com/fiji-hpc/hpc-datastore/assets/10509335/84a1b43b-6977-4edb-b2b8-fa0a1e35cadc)

Example of debug messages from the commit 2768584ead4dc3:
![Screenshot_20230609_194155](https://github.com/fiji-hpc/hpc-datastore/assets/10509335/423ef2c1-399a-4408-a66d-17a106506360)
